### PR TITLE
Added an endpoint to get the time of the last request in observation

### DIFF
--- a/src/controller/ObservationController.js
+++ b/src/controller/ObservationController.js
@@ -20,6 +20,7 @@ var staticObservations = [];
 var activeDevices = [];
 var lastRequestData = {};
 var logData = [];
+var lastRequestTime = null;
 
 // start updating after 1 minutes of starting the middleware
 let lastUpdatedToCare = new Date() - 59 * 60 * 1000;
@@ -202,7 +203,7 @@ const updateObservationsToCare = async () => {
       console.log("Building Payload");
 
       // additional check to see if temperature is within range
-      console.log(data)
+      console.log(data);
       let temperature = getValueFromData(data["body-temperature1"]?.[0]);
       let temperature_measured_at = null;
       // const temperature_low_limit = data["body-temperature1"]?.[0]?.["low-limit"];
@@ -371,9 +372,17 @@ export class ObservationController {
     return res.json(lastRequestData);
   }
 
+  static getLastRequestTime = async (req, res) => {
+    res.send({
+      time: lastRequestTime?.toISOString() ?? null,
+      within_last_minute: dayjs().diff(lastRequestTime, "minute") < 1,
+    });
+  };
+
   static updateObservations = (req, res) => {
     // database logic
     lastRequestData = req.body;
+    lastRequestTime = new Date();
     // console.log("updateObservations", req.body);
     addLogData(req.body);
     const observations = req.body;

--- a/src/controller/ObservationController.js
+++ b/src/controller/ObservationController.js
@@ -373,9 +373,10 @@ export class ObservationController {
   }
 
   static getLastRequestTime = async (req, res) => {
-    res.send({
+    const withinLastMinute = dayjs().diff(lastRequestTime, "minute") < 1;
+    const statusCode = withinLastMinute ? 200 : 412; // 412 Precondition Failed ( update_observations has not been called in the last minute )
+    res.status(statusCode).send({
       time: lastRequestTime?.toISOString() ?? null,
-      within_last_minute: dayjs().diff(lastRequestTime, "minute") < 1,
     });
   };
 

--- a/src/router/observationRouter.js
+++ b/src/router/observationRouter.js
@@ -27,4 +27,6 @@ router.get("/get_log_data", ObservationController.getLogData);
 
 router.get("/get_last_request_data", ObservationController.getLastRequestData);
 
+router.get("/get_last_request_time", ObservationController.getLastRequestTime);
+
 export { router as observationRouter };


### PR DESCRIPTION
Fixes #61 

endpoint: `GET get_last_request_time`
response: 
```json 
{
  "time": "2022-12-07T11:39:36.276Z",
  "within_last_minute": false
}
```

_@gigincg We already seem to have `GET get_last_request_data` can we just merge the above into this and just have a single endpoint?_