### PR TITLE
Remove camerasStatusBodyValidators and fix timeout

### DIFF
--- a/src/Validators/cameraValidators.js
+++ b/src/Validators/cameraValidators.js
@@ -46,29 +46,7 @@ export const baseGetCameraParamsValidators = [
     .withMessage("port must be integer."),
 ];
 
-export const camerasStatusBodyValidators = [
-  body().isArray().withMessage("body must be a valid array."),
-  body("*.hostname")
-    .exists({ checkFalsy: true })
-    .withMessage("hostname is required.")
-    .isString()
-    .withMessage("hostname must be string."),
-  body("*.username")
-    .exists({ checkFalsy: true })
-    .withMessage("username is required.")
-    .isString()
-    .withMessage("username must be string."),
-  body("*.password")
-    .exists({ checkFalsy: true })
-    .withMessage("password is required.")
-    .isString()
-    .withMessage("password must be string."),
-  body("*.port")
-    .exists({ checkFalsy: true })
-    .withMessage("port is required.")
-    .isInt()
-    .withMessage("port must be integer."),
-];
+
 
 export const gotoPresetValidator = [
   ...baseCameraParamsValidators,

--- a/src/Validators/cameraValidators.js
+++ b/src/Validators/cameraValidators.js
@@ -46,8 +46,6 @@ export const baseGetCameraParamsValidators = [
     .withMessage("port must be integer."),
 ];
 
-
-
 export const gotoPresetValidator = [
   ...baseCameraParamsValidators,
   body("preset")

--- a/src/router/cameraRouter.js
+++ b/src/router/cameraRouter.js
@@ -5,7 +5,6 @@ import { CameraController } from "../controller/CameraController.js";
 import { validate } from "../middleware/validate.js";
 import {
   baseCameraParamsValidators,
-  camerasStatusBodyValidators,
   setPresetValidators,
   baseGetCameraParamsValidators,
   camMoveValidator,
@@ -34,7 +33,6 @@ router.get(
 
 router.post(
   "/cameras/status",
-  validate(camerasStatusBodyValidators),
   CameraController.getCameraStatuses
 );
 

--- a/src/utils/CameraUtils.js
+++ b/src/utils/CameraUtils.js
@@ -3,7 +3,7 @@ import * as onvif from "onvif";
 const Cam = onvif.Cam;
 
 export class CameraUtils {
-  constructor() {}
+  constructor() { }
 
   static gotoPreset = async ({ camParams, preset }) =>
     new Promise((resolve, reject) => {
@@ -30,7 +30,7 @@ export class CameraUtils {
   static getStatus = async ({ camParams }) =>
     new Promise(
       (resolve, reject) =>
-        new Cam(camParams, function (err) {
+        new Cam({ ...camParams, timeout: 5000 }, function (err) {
           if (err) return reject(err);
           this.getStatus({}, (error, status) => {
             if (error) return reject(error);
@@ -70,7 +70,7 @@ export class CameraUtils {
       new Cam(camParams, function (err) {
         if (err) return reject(err);
         try {
-          const result = this.setPreset({ presetName }, () => {});
+          const result = this.setPreset({ presetName }, () => { });
           resolve(result);
         } catch (error) {
           reject(error);
@@ -78,7 +78,7 @@ export class CameraUtils {
       });
     });
 
-  static getSnapshotUri = async ({ camParams }) => 
+  static getSnapshotUri = async ({ camParams }) =>
     new Promise((resolve, reject) => {
       new Cam(camParams, function (err) {
         if (err) return reject(err);
@@ -95,5 +95,5 @@ export class CameraUtils {
 
 
 
-  
+
 }


### PR DESCRIPTION
Fixes [#98](https://github.com/coronasafe/teleicu_middleware/issues/98) 

This PR removes the `camerasStatusBodyValidators` middleware from the "/cameras/status" endpoint.

The middleware was previously used to validate the request body for the POST route. However, it was found that the middleware was causing issues when any camera asset under the same middleware was misconfigured. This led to the middleware incorrectly marking all assets as 'down'.

To resolve this, the validation has been removed from the middleware and instead added directly within the `fetchCameraStatuses` function in the `CameraController`. This allows the function to ignore any misconfigured assets and continue processing the remaining assets.

The changes in this PR include:

1. Removal of `camerasStatusBodyValidators` from `cameraValidators.js`
2. Removal of `validate(camerasStatusBodyValidators)` from the POST route in `cameraRouter.js`