### PR TITLE
use lower sample rate by default for sentry

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -70,7 +70,7 @@ Sentry.init({
     new Tracing.Integrations.Express({ app }),
   ],
   environment: process.env.SENTRY_ENV,
-  tracesSampleRate: 1.0,
+  tracesSampleRate: parseFloat(process.env.SENTRY_SAMPLE_RATE) || 0.01,
 });
 
 app.use(Sentry.Handlers.requestHandler());


### PR DESCRIPTION
- currently we are getting 150+ transactions a second which is a lot for a production environment

- this does not affect error events